### PR TITLE
More people admin changes

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -305,6 +305,18 @@ STATICFILES_FINDERS += ["compressor.finders.CompressorFinder"]
 # Jet
 # ------------------------------------------------------------------------------
 JET_SIDE_MENU_COMPACT = True
+JET_THEMES = [
+    {
+        "theme": "default",  # theme folder name
+        "color": "#47bac1",  # color of the theme's button in user menu
+        "title": "Default",  # theme title
+    },
+    {"theme": "green", "color": "#44b78b", "title": "Green"},
+    {"theme": "light-green", "color": "#2faa60", "title": "Light Green"},
+    {"theme": "light-violet", "color": "#a464c4", "title": "Light Violet"},
+    {"theme": "light-blue", "color": "#5EADDE", "title": "Light Blue"},
+    {"theme": "light-gray", "color": "#222", "title": "Light Gray"},
+]
 
 # dj-places
 # ------------------------------------------------------------------------------

--- a/kosha/people/admin.py
+++ b/kosha/people/admin.py
@@ -12,7 +12,7 @@ class MeetingInline(admin.StackedInline):
 
 
 @admin.register(Person)
-class PersonAdmin(VersionAdmin):
+class PersonAdmin(DjangoQLSearchMixin, VersionAdmin):
     list_display = (
         "name",
         "reference_number",

--- a/kosha/people/admin.py
+++ b/kosha/people/admin.py
@@ -24,6 +24,8 @@ class PersonAdmin(DjangoQLSearchMixin, VersionAdmin):
         "relation_with_gm",
         "marital_status",
         "temple",
+        "first_initiation_place",
+        "first_initiation_date",
     )
     list_select_related = ("nationality", "zone", "temple", "country")
     list_filter = (
@@ -34,7 +36,14 @@ class PersonAdmin(DjangoQLSearchMixin, VersionAdmin):
         "relation_with_gm",
         "temple",
     )
-    search_fields = ("reference_number", "name", "mobile", "email")
+    search_fields = (
+        "reference_number",
+        "name",
+        "initiatied_name",
+        "mobile",
+        "email",
+        "first_initiation_place",
+    )
     readonly_fields = (
         # "reference_number",
         "approved_by",

--- a/kosha/people/admin.py
+++ b/kosha/people/admin.py
@@ -1,11 +1,6 @@
 from django.contrib import admin
 
 from djangoql.admin import DjangoQLSearchMixin
-from django_admin_listfilter_dropdown.filters import (
-    DropdownFilter,
-    RelatedDropdownFilter,
-    ChoiceDropdownFilter,
-)
 from reversion.admin import VersionAdmin
 
 from kosha.people.models import Person, Guru, GuruRole, Meeting, Address, Occupation
@@ -17,30 +12,31 @@ class MeetingInline(admin.StackedInline):
 
 
 @admin.register(Person)
-class PersonAdmin(DjangoQLSearchMixin, VersionAdmin):
+class PersonAdmin(VersionAdmin):
     list_display = (
         "name",
         "reference_number",
-        "nationality",
         "mobile",
         "email",
+        "nationality",
+        "zone",
         "care_level",
         "relation_with_gm",
-        "zone",
-        "temple",
         "marital_status",
+        "temple",
     )
+    list_select_related = ("nationality", "zone", "temple", "country")
     list_filter = (
-        ("care_level", DropdownFilter),
-        ("relation_with_gm", DropdownFilter),
-        ("nationality", RelatedDropdownFilter),
-        ("country", RelatedDropdownFilter),
-        ("zone", RelatedDropdownFilter),
-        ("temple", RelatedDropdownFilter),
+        "zone",
+        "nationality",
+        "country",
+        "care_level",
+        "relation_with_gm",
+        "temple",
     )
     search_fields = ("reference_number", "name", "mobile", "email")
     readonly_fields = (
-        "reference_number",
+        # "reference_number",
         "approved_by",
         "approved_at",
         "created_at",
@@ -58,6 +54,10 @@ class PersonAdmin(DjangoQLSearchMixin, VersionAdmin):
                     ("dob", "dob_type"),
                     ("dod", "life_status"),
                     ("nationality", "occupation"),
+                    ("country",),
+                    ("zone"),
+                    ("marital_status"),
+                    ("care_level", "relation_with_gm"),
                 )
             },
         ),
@@ -68,7 +68,6 @@ class PersonAdmin(DjangoQLSearchMixin, VersionAdmin):
                     ("mobile", "phone", "email"),
                     ("address_line_1", "address_line_2", "locality"),
                     ("zipcode", "state"),
-                    ("country"),
                     ("permanent_address_same_as_current",),
                     (
                         "permanent_address_line_1",
@@ -77,19 +76,14 @@ class PersonAdmin(DjangoQLSearchMixin, VersionAdmin):
                     ),
                     ("permanent_zipcode", "permanent_state"),
                     ("permanent_country"),
-                    ("zone"),
                 )
             },
         ),
-        (
-            "Family details",
-            {"fields": (("marital_status",), ("spouse",), ("children_names",))},
-        ),
+        ("Family details", {"fields": (("spouse",), ("children_names",))}),
         (
             "Spiritual details",
             {
                 "fields": (
-                    ("care_level", "relation_with_gm"),
                     ("shelter_guru",),
                     ("shelter_date", "shelter_recommendation"),
                     ("shelter_place",),

--- a/kosha/people/admin.py
+++ b/kosha/people/admin.py
@@ -163,6 +163,11 @@ class PersonAdmin(DjangoQLSearchMixin, VersionAdmin):
         ),
     )
 
+    def get_queryset(self, request):
+        queryset = super().get_queryset(request)
+        queryset.select_related(*self.list_select_related)
+        return queryset
+
 
 @admin.register(Guru)
 class GuruAdmin(VersionAdmin):

--- a/kosha/people/models.py
+++ b/kosha/people/models.py
@@ -146,7 +146,6 @@ class Person(BaseModel):
     # Basic fields
     reference_number = CharField(
         max_length=15,
-        editable=False,
         unique=True,
         db_index=True,
         help_text=_("Unique reference number for the devotee"),

--- a/kosha/static/djangoql/css/completion_admin.css
+++ b/kosha/static/djangoql/css/completion_admin.css
@@ -1,0 +1,9 @@
+#changelist #toolbar form textarea#searchbar {
+  width: 30%;
+  height: 32px !important;
+}
+
+.djangoql-toggle {
+  margin-right: 10px;
+  display: block !important;
+}


### PR DESCRIPTION
- Fix DjangoSQL search bar issues with `JET` admin theme
- Remove `django-admin-filter-dropdown`
- Add JET themes in settings
- Other changes in `people.Person` admin pages
- Use select_related query to load `people.Person` change page faster